### PR TITLE
Fix bug in apply spike raster

### DIFF
--- a/src/processor_help.cpp
+++ b/src/processor_help.cpp
@@ -293,7 +293,7 @@ void apply_spike_raster(Processor *p, int in_neuron, const vector <char> &sr, in
   for (i = 0; i < sr.size(); i++) {
     if (sr[i]) {
       s.time = i;
-      p->apply_spike(s, network_id);
+      p->apply_spike(s, true, network_id);
     }
   }
 }


### PR DESCRIPTION
Ran into a small bug during testing. When using Apply Spike Raster through processor tool it is incorrectly calling the function `apply_spike`. `apply_spike` has the function signature...
```c++
void apply_spike(const Spike& s, bool normalized = true, int network_id = 0)
```
meaning that the `network_id` was being implicitly cast to a bool and provided as the `normalized` parameter. 

I'm unsure if `normalized = true` is the correct behavior here, but I just stuck with the default.