### PR TITLE
Don't throw error for `track_all_neuron_events`

### DIFF
--- a/src/processor_tool.cpp
+++ b/src/processor_tool.cpp
@@ -839,7 +839,9 @@ int main(int argc, char **argv)
         if (network_processor_validation(net, p)) {
           if (sv.size() == 1) {
             if (sv[0][0] == 'T') {
-              (void) track_all_neuron_events(p, net);
+              if (!track_all_neuron_events(p, net)) {
+                printf("track_all_neuron_events() not supported by processor.\n");
+              }
             } else {
               for (nit = net->begin(); nit != net->end(); nit++) {
                 p->track_neuron_events(nit->second->id, false);

--- a/src/processor_tool.cpp
+++ b/src/processor_tool.cpp
@@ -248,7 +248,7 @@ Network *load_network(Processor **pp,
   }
 
   if (!p->load_network(net)) throw SRE("load_network() failed");
-  if (!track_all_neuron_events(p, net)) throw SRE("track_all_neuron_events() failed.");
+  track_all_neuron_events(p, net);
 
   return net;
 }


### PR DESCRIPTION
https://github.com/TENNLab-UTK/framework-open/blob/1d2b76910da0158c7267302317b6b6bdabc6c06e/markdown/processor.md?plain=1#L209-L211

The markdown indicates that this method can return false if unsupported, yet the processor tool requires it to return true otherwise it throws an error. This change prevents the processor tool from throwing an error by ignore the return value of `track_all_neuron_events`.