### PR TITLE
Add RISP FPGA support via updated Python bindings and .toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = [
+    "scikit_build_core[pyproject]",
+    "pybind11",
+]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "framework"
+version = "0.0.0"
+requires-python = ">=3.7"
+
+dependencies = [
+    "ipython",
+    "notebook",
+    "pyglet",
+    "six",
+    "pillow",
+    "imageio",
+    "numpy",
+    "scipy",
+    "scikit-learn",
+    "pandas",
+    "matplotlib",
+    "gymnasium",
+    "networkx"
+]
+


### PR DESCRIPTION
Just adds a few more Python bindings and a .toml file that allows the open source framework to be pip installed.